### PR TITLE
Docker compose setup: better permissions management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,19 +5,11 @@ BACKEND = @$(DOCKER_COMPOSE) run --rm backend
 FRONTEND = @$(DOCKER_COMPOSE) run --rm frontend
 
 up:
-	$(MAKE) fix-permissions
 	$(DOCKER_COMPOSE) up --build # --force-recreate
 
 build:
-	$(MAKE) fix-permissions
 	$(DOCKER_COMPOSE) build
 	$(FRONTEND) bash -c "node --version && yarn install"
-	$(MAKE) fix-permissions
-
-fix-permissions:
-	# Note: there should be better way to handle this.
-	sudo chown -R $(USER):$(USER) frontend
-	sudo chown -R $(USER):$(USER) backend
 
 recreate-local-db:
 	$(DOCKER_COMPOSE) stop backend

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Frontend setup:
 - Linting with typescript, eslint and prettier
 - Code formatting with prettier
 
+Note: on linux, to fix permissions between host / docker shared containers, it is necessary to export `$UID` and `$GID` variables, this can be done in ~/.bashrc or ~/.zshrc.
+This is becuase UID and GID are shell variables, not env variables.
+It allows to have dependencies (python venv and node.js node_modules shared from the container to the host, so we can have IDE completion on the host, or just easily access the dependencies from the editor).
+See also: https://github.com/docker/compose/issues/2380.
+
 Rebuild images / reinstall dependencies: `make build`.
 Note: the dependencies are installed into the volume shared with the host system, so are available inside the source folders (so IDEs, for example, can use them for autocomplete, or people can use as a reference to quickly check how things are implemented inside the packages).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     command: flask run
     # command: /bin/bash -c "sleep infinity & wait"
     volumes:
-      - ./backend:/src
+      - ./backend:/src:cached
     ports:
       - "5000:5000"
     environment:
@@ -29,12 +29,12 @@ services:
 
   frontend:
     restart: always
-    user: "${UID}:${GID}"
     build:
       context: frontend
       dockerfile: Dockerfile
+    user: "${UID}:${GID}"
     volumes:
-      - ./frontend:/src
+      - ./frontend:/src:cached
     ports:
       - "8080:8080"
     command: npm run serve

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,12 @@ services:
     build:
       context: backend
       dockerfile: Dockerfile
+    # User setting to have files with correct permissions on the host.
+    # Requires export $UID=$UID and export $GID=$GID somewhere (~/.bashrc or ~/.zshrc)
+    # This is becuase UID and GID are shell variables, not env variables,
+    # so it doesn't work without export.
+    # See also: https://github.com/docker/compose/issues/2380
+    user: "${UID}:${GID}"
     # Entrypoint installs python dependencies if needed.
     entrypoint: ./docker-entrypoint.sh
     command: flask run
@@ -23,6 +29,7 @@ services:
 
   frontend:
     restart: always
+    user: "${UID}:${GID}"
     build:
       context: frontend
       dockerfile: Dockerfile
@@ -34,6 +41,7 @@ services:
 
   postgresql:
     image: postgres:11.2
+    user: "${UID}:${GID}"
     environment:
       POSTGRES_USER: testuser
       POSTGRES_PASSWORD: testpw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,12 +32,12 @@ services:
     build:
       context: frontend
       dockerfile: Dockerfile
+    command: /bin/bash -c "yarn install && yarn serve"
     user: "${UID}:${GID}"
     volumes:
       - ./frontend:/src:cached
     ports:
       - "8080:8080"
-    command: npm run serve
 
   postgresql:
     image: postgres:11.2


### PR DESCRIPTION
Remove "hacky" solution with 'chown' before / after running the compose setup, replace with `USER` setting.