### PR TITLE
Update to current Docker Compose, add depends_on, fix Vue proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_COMPOSE = docker-compose
+DOCKER_COMPOSE = docker compose
 PG_URI = postgresql://testuser:testpw@postgresql:5432
 
 BACKEND = @$(DOCKER_COMPOSE) run --rm backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   backend:
     restart: always
@@ -17,6 +15,8 @@ services:
 
     entrypoint: ./docker-entrypoint.sh
     command: flask run
+    depends_on:
+      - postgresql
     volumes:
       - ./backend:/backend
     ports:
@@ -38,6 +38,8 @@ services:
         - GID=$GID
     user: "node"
     command: /bin/bash -c "yarn install && yarn serve"
+    depends_on:
+      - backend
     volumes:
       - ./frontend:/frontend
     ports:

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   devServer: {
-    proxy: 'http://localhost:5000/',
+    proxy: 'http://backend:5000/',
     /*
     proxy: {
       '/api*': {


### PR DESCRIPTION
Switch to the current (plugin) version of Docker Compose.

Set the depends_on links within the Compose file, to controls startup/shutdown order.

Fix the Vue.js devServer.proxy value to point to the container name.  This fixes problems with hot module reloading.